### PR TITLE
Fix #54 User option for debugging purpose added

### DIFF
--- a/wallabagger/js/background.js
+++ b/wallabagger/js/background.js
@@ -119,6 +119,7 @@ browser.commands.onCommand.addListener(function (command) {
 });
 
 GetApi().then(api => {
+    api.resetDebug();
     if (api.data.AllowExistCheck) {
         browser.tabs.onActivated.addListener(function (activeInfo) {
             browser.browserAction.setIcon({ path: icon.default });

--- a/wallabagger/js/options.js
+++ b/wallabagger/js/options.js
@@ -23,6 +23,7 @@ var OptionsController = function () {
     //   this.tokenExpiresInput = document.getElementById("tokenexpired-input");
     this.allowSpaceCheck = document.getElementById('allow-space-checkbox');
     this.allowExistCheck = document.getElementById('allow-exist-checkbox');
+    this.debugEl = document.getElementById('debug');
     this.saveToFileButton = document.getElementById('saveToFile-button');
     this.loadFromFileButton = document.getElementById('loadFromFile-button');
     this.clearButton = document.getElementById('clear-button');
@@ -65,6 +66,7 @@ OptionsController.prototype = {
 
     allowSpaceCheck: null,
     allowExistCheck: null,
+    debugEl: null,
     httpsButton: null,
     httpsMessage: null,
 
@@ -73,6 +75,7 @@ OptionsController.prototype = {
     addListeners_: function () {
         this.allowSpaceCheck.addEventListener('click', this.allowSpaceCheckClick.bind(this));
         this.allowExistCheck.addEventListener('click', this.allowExistCheckClick.bind(this));
+        this.debugEl.addEventListener('click', this.debugClick.bind(this));
         this.protocolCheck_.addEventListener('click', this.handleProtocolClick.bind(this));
         // this.savebutton_.addEventListener('click', this.saveClick_.bind(this));
         this.checkurlbutton_.addEventListener('click', this.checkUrlClick.bind(this));
@@ -124,9 +127,11 @@ OptionsController.prototype = {
             let fileReader = new FileReader();
             fileReader.onload = function (fileLoadedEvent) {
                 let textFromFileLoaded = fileLoadedEvent.target.result;
-                console.log(textFromFileLoaded);
                 let obj = JSON.parse(textFromFileLoaded);
-                console.log(obj);
+                if(this.api.data.Debug === true) {
+                    console.log(textFromFileLoaded);
+                    console.log(obj);
+                }
                 this.api.set(obj);
                 this.setFields(obj);
                 this.api.save();
@@ -163,6 +168,11 @@ OptionsController.prototype = {
             this.allowExistCheck.checked = false;
             this.httpsMessage.classList.add('active');
         }
+    },
+
+    debugClick: function () {
+        this.api.set({ Debug: this.debugEl.checked });
+        this.api.save();
     },
 
     wallabagApiTokenGot: function () {
@@ -353,6 +363,7 @@ OptionsController.prototype = {
 
         this.allowSpaceCheck.checked = data.AllowSpaceInTags;
         this.allowExistCheck.checked = data.AllowExistCheck;
+        this.debugEl.checked = data.Debug;
     },
 
     init: function () {

--- a/wallabagger/js/popup.js
+++ b/wallabagger/js/popup.js
@@ -400,11 +400,15 @@ PopupController.prototype = {
         apiAuthorised.then(data => this.activeTab())
             .then(tab => {
                 this.showInfo('Saving the page to wallabag ...');
-                console.log(tab.url);
+                if(this.api.data.Debug === true) {
+                    console.log(tab.url);
+                }
                 return this.api.SavePage(tab.url);
             })
             .then(data => {
-                console.log(data);
+                if(this.api.data.Debug === true) {
+                    console.log(data);
+                }
                 if (data != null) {
                     this.articleId = data.id;
                     this.cardTitle.innerHTML = data.title;

--- a/wallabagger/js/wallabag-api.js
+++ b/wallabagger/js/wallabag-api.js
@@ -1,30 +1,37 @@
 var WallabagApi = function () { };
 
-const emptyData = {
-    Url: null,
-    ApiVersion: null,
-    ClientId: null,
-    ClientSecret: null,
-    UserLogin: null,
-    UserPassword: null,
-    ApiToken: null,
-    RefreshToken: null,
-    ExpireDateMs: null,
-    AllowSpaceInTags: null,
-    AllowExistCheck: null
-};
-
 WallabagApi.prototype = {
 
-    data: emptyData,
+    defaultValues: {
+        Url: null,
+        ApiVersion: null,
+        ClientId: null,
+        ClientSecret: null,
+        UserLogin: null,
+        UserPassword: null,
+        ApiToken: null,
+        RefreshToken: null,
+        ExpireDateMs: null,
+        AllowSpaceInTags: null,
+        AllowExistCheck: null,
+        Debug: false
+    },
+
+    data: {},
 
     fetchApi: null,
 
     tags: [],
 
     init: function () {
+        Object.assign(this.data, this.defaultValues);
         this.fetchApi = new FetchApi();
         return this.load();
+    },
+
+    resetDebug: function() {
+        this.data.Debug = this.defaultValues.Debug;
+        this.save();
     },
 
     save: function () {
@@ -71,7 +78,7 @@ WallabagApi.prototype = {
     },
 
     clear: function () {
-        this.set(emptyData);
+        this.set(this.defaultValues);
     },
 
     set: function (params) {

--- a/wallabagger/options.html
+++ b/wallabagger/options.html
@@ -132,6 +132,13 @@
                                 <i class="form-icon"></i>Indicate if page already saved (this sends URL of each tab to wallabag, use HTTPS protocol for better security!)
                             </label>
                         </div>
+
+                        <div class="form-group">
+                            <label class="form-switch">
+                                <input type="checkbox" id="debug"/>
+                                <i class="form-icon"></i>Enable this only if developers told you to.
+                            </label>
+                        </div>
                     </section>
             </div>    
         </div>


### PR DESCRIPTION
Add an option into the option page the user can toggle to enable/disable the debug lines.
The option is toggle off on browser restart to be sure it is not kept on.