### PR TITLE
Correction d'une erreur de traduction

### DIFF
--- a/wallabagger/_locales/fr/messages.json
+++ b/wallabagger/_locales/fr/messages.json
@@ -128,7 +128,7 @@
     "description": "Options"
   },
   "No_leave_it": {
-    "message": "Non, le supprimer",
+    "message": "Non, le conserver",
     "description": "Popup"
   },
   "Not_checked": {


### PR DESCRIPTION
Le "Non, le supprimer" induit en erreur car si on veut vraiment supprimer, il faut appuyer sur "Oui, le supprimer"