### PR TITLE
don't set Cookie header (fixes #149, maybe #140)

### DIFF
--- a/wallabagger/js/fetch-api.js
+++ b/wallabagger/js/fetch-api.js
@@ -7,7 +7,8 @@ FetchApi.prototype = {
             method: method,
             headers: this.getHeaders(token),
             mode: 'cors',
-            cache: 'default'
+            cache: 'default',
+            credentials: 'omit'
         };
         if (content !== '') {
             options = Object.assign(options, { body: JSON.stringify(content) });


### PR DESCRIPTION
seems to default to same-origin per https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch