### PR TITLE
Add option to archive by default when saving the page

### DIFF
--- a/wallabagger/_locales/de/messages.json
+++ b/wallabagger/_locales/de/messages.json
@@ -266,5 +266,9 @@
   "You_can_find_your_credentials_here": {
     "message": "Ihre Zugangsdaten finden Sie hier:",
     "description": "Options"
-  }
+  },
+    "Archive_by_default_when_saving_page": {
+        "message": "Standardmäßig markieren Sie die Seite beim Speichern als gelesen",
+        "description": "Options"
+    }
 }

--- a/wallabagger/_locales/en/messages.json
+++ b/wallabagger/_locales/en/messages.json
@@ -266,5 +266,9 @@
   "You_can_find_your_credentials_here": {
     "message": "You can find your credentials here:",
     "description": "Options"
+  },
+  "Archive_by_default_when_saving_page": {
+    "message": "Archive by default when saving the page",
+    "description": "Options"
   }
 }

--- a/wallabagger/_locales/fr/messages.json
+++ b/wallabagger/_locales/fr/messages.json
@@ -266,5 +266,9 @@
   "You_can_find_your_credentials_here": {
     "message": "Vous pouvez trouver vos identifiants ici :",
     "description": "Options"
-  }
+  },
+    "Archive_by_default_when_saving_page": {
+        "message": "Par défaut, marque la page comme lue lors de son enregistrement",
+        "description": "Options"
+    }
 }

--- a/wallabagger/_locales/ru/messages.json
+++ b/wallabagger/_locales/ru/messages.json
@@ -278,5 +278,9 @@
   "You_can_find_your_credentials_here": {
     "message": "Ваши учётные данные ищите здесь",
     "description": "Options"
-  }
+  },
+    "Archive_by_default_when_saving_page": {
+        "message": "Архивировать при сохранении",
+        "description": "Options"
+    }
 }

--- a/wallabagger/js/options.js
+++ b/wallabagger/js/options.js
@@ -18,6 +18,7 @@ var OptionsController = function () {
 
     this.allowSpaceCheck = document.getElementById('allow-space-checkbox');
     this.allowExistCheck = document.getElementById('allow-exist-checkbox');
+    this.archiveByDefault = document.getElementById('archive-by-default-checkbox');
     this.debugEl = document.getElementById('debug');
     this.saveToFileButton = document.getElementById('saveToFile-button');
     this.loadFromFileButton = document.getElementById('loadFromFile-button');
@@ -52,6 +53,7 @@ OptionsController.prototype = {
     clearButton: null,
 
     allowSpaceCheck: null,
+    archiveByDefault: null,
     allowExistCheck: null,
     debugEl: null,
     httpsButton: null,
@@ -62,6 +64,7 @@ OptionsController.prototype = {
 
     addListeners_: function () {
         this.allowSpaceCheck.addEventListener('click', this.allowSpaceCheckClick.bind(this));
+        this.archiveByDefault.addEventListener('click', this.archiveByDefaultClick.bind(this));
         this.allowExistCheck.addEventListener('click', this.allowExistCheckClick.bind(this));
         this.debugEl.addEventListener('click', this.debugClick.bind(this));
         this.protocolCheck_.addEventListener('click', this.handleProtocolClick.bind(this));
@@ -136,6 +139,11 @@ OptionsController.prototype = {
 
     allowSpaceCheckClick: function (e) {
         Object.assign(this.data, { AllowSpaceInTags: this.allowSpaceCheck.checked });
+        this.port.postMessage({ request: 'setup-save', data: this.data });
+    },
+
+    archiveByDefaultClick: function (e) {
+        Object.assign(this.data, { ArchiveByDefault: this.archiveByDefault.checked });
         this.port.postMessage({ request: 'setup-save', data: this.data });
     },
 

--- a/wallabagger/js/wallabag-api.js
+++ b/wallabagger/js/wallabag-api.js
@@ -175,7 +175,7 @@ WallabagApi.prototype = {
     },
 
     SavePage: function (pageUrl) {
-        const content = { url: pageUrl };
+        const content = { url: pageUrl, archive: this.data.ArchiveByDefault ? 1 : 0 };
         const entriesUrl = `${this.data.Url}/api/entries.json`;
         return this.CheckToken().then(a =>
             this.fetchApi.Post(entriesUrl, this.data.ApiToken, content)

--- a/wallabagger/options.html
+++ b/wallabagger/options.html
@@ -198,6 +198,13 @@
 
             <div class="form-group">
                 <label class="form-switch">
+                    <input type="checkbox" id="archive-by-default-checkbox"/>
+                    <i class="form-icon"></i><span data-i18n="Archive_by_default_when_saving_page">Archive by default when saving page</span>
+                </label>
+            </div>
+
+            <div class="form-group">
+                <label class="form-switch">
                     <input type="checkbox" id="debug"/>
                     <i class="form-icon"></i><span data-i18n="Enable_this_only_if_developers_told_you_to">Enable this only if developers told you to.</span>
                 </label>


### PR DESCRIPTION
First of all, I am very happy with the Wallabagger extension. I use it dozens of times every day, with two scenarios. 

First, and by far most commonly, to archive what I already have read. 
And secondly, to keep a list of everything that I still want to read at a later time.

For the first use case, I need to save the page, and then archive it. This workflow has two annoyances:

1. Saving and then archiving a page takes two clicks.
1. When saving a page, the title and an image are loaded. This replaces the current content in the save box, moving the action bar. Since that is also where the _Archive_ button is, it is a common occurrence for me to actually miss that button, due to the movement. This then takes me to the corresponding page in Wallabag.

This MR addresses the first of these issues. Therefore, I hope that you will consider including this in a future release.

Thank you.