### PR TITLE
Default popup wallabag icon style updated

### DIFF
--- a/wallabagger/css/popup.css
+++ b/wallabagger/css/popup.css
@@ -64,11 +64,17 @@ body {
     box-shadow: 0 0 0 0.1rem rgba(87, 85, 217, 0.2);
 }
 
-#card-image {
+.card-image {
     max-width: 444px;
     max-height: 250px;
     overflow: hidden;
     margin: auto;
+}
+
+.card-image--default {
+    max-height: 100px;
+    margin-top: 14px;
+    margin-bottom: 14px;
 }
 
 .pb-30 {

--- a/wallabagger/js/popup.js
+++ b/wallabagger/js/popup.js
@@ -496,6 +496,7 @@ PopupController.prototype = {
         if (typeof (data.preview_picture) === 'string' &&
             data.preview_picture.length > 0 &&
             data.preview_picture.indexOf('http') === 0) {
+            this.cardImage.classList.remove('card-image--default');
             this.cardImage.src = data.preview_picture;
         }
 

--- a/wallabagger/popup.html
+++ b/wallabagger/popup.html
@@ -13,9 +13,7 @@
 <body>
     <div class="card" id="main-card">
 
-        <div class="card-image">
-            <img src="img/wallabag-icon-128.png" class="card-image img-responsive" id="card-image" />
-        </div>
+        <img src="img/wallabag-icon-128.png" class="card-image card-image--default img-responsive" id="card-image" />
 
         <div class="card-header" id="card-header">
             <a


### PR DESCRIPTION
I updated the default image spacing.
![wallabagger-default-image](https://user-images.githubusercontent.com/582666/98444556-9c47a100-2112-11eb-9c1a-421dd1a1ac59.png)

Closes #196