### PR TITLE
popup: Make delete button primary

### DIFF
--- a/wallabagger/popup.html
+++ b/wallabagger/popup.html
@@ -124,8 +124,8 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button class="btn btn-link" id="delete-article" data-i18n="Yes_delete_it">Yes, delete it</button>
-                <button class="btn btn-primary" id="cancel-confirmation" data-i18n="No_leave_it">No, leave it</button>
+                <button class="btn btn-error" id="delete-article" data-i18n="Yes_delete_it">Yes, delete it</button>
+                <button class="btn btn-link" id="cancel-confirmation" data-i18n="No_leave_it">No, leave it</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Delete is the primary action in the dialogue so it should be highlighted as such.

### Before

![image](https://user-images.githubusercontent.com/705123/110113580-98234b80-7db3-11eb-8d05-fe37dd354b1e.png)

### After

![image](https://user-images.githubusercontent.com/705123/110113595-9e192c80-7db3-11eb-9620-2fa1e848255d.png)
