### PR TITLE
Adds an option to locally fetch site website content

### DIFF
--- a/wallabagger/_locales/en/messages.json
+++ b/wallabagger/_locales/en/messages.json
@@ -247,6 +247,10 @@
     "message": "User password",
     "description": "Options"
   },
+  "Sites_locally": {
+    "message": "Sites to fetch locally",
+    "description": "Options"
+  },
   "Wallabag_API_token": {
     "message": "Wallabag API token",
     "description": "Options"

--- a/wallabagger/js/background.js
+++ b/wallabagger/js/background.js
@@ -213,7 +213,7 @@ function onPortMessage (msg) {
     try {
         switch (msg.request) {
             case 'save':
-                savePageToWallabag(msg.tabUrl, false);
+                savePageToWallabag(msg.tabUrl, false, msg.title, msg.content);
                 break;
             case 'tags':
                 if (!cache.check('allTags')) {
@@ -463,7 +463,7 @@ function moveToDirtyCache (url) {
     }
 }
 
-function savePageToWallabag (url, resetIcon) {
+function savePageToWallabag (url, resetIcon, title, content) {
     if (isServicePage(url)) {
         return;
     }
@@ -493,7 +493,18 @@ function savePageToWallabag (url, resetIcon) {
     browserIcon.set('wip');
     existCache.set(url, existStates.wip);
     postIfConnected({ response: 'info', text: Common.translate('Saving_the_page_to_wallabag') });
-    api.SavePage(url)
+
+    const savePageOptions = {
+        url: url
+    };
+
+    if (api.IsSiteToFetchLocally(url)) {
+        savePageOptions.title = title;
+        savePageOptions.content = content;
+    }
+
+    const promise = api.SavePage(savePageOptions);
+    promise
         .then(data => applyDirtyCacheLight(url, data))
         .then(data => {
             if (!data.deleted) {

--- a/wallabagger/js/options.js
+++ b/wallabagger/js/options.js
@@ -14,6 +14,7 @@ const OptionsController = function () {
     this.clientSecret_ = document.getElementById('clientsecret-input');
     this.userLogin_ = document.getElementById('userlogin-input');
     this.userPassword_ = document.getElementById('userpassword-input');
+    this.sitesToFetchLocally_ = document.getElementById('sites_to_fetch_locally-textarea');
     this.getAppTokenButton_ = document.getElementById('getapptoken-button');
     this.tokenLabel_ = document.getElementById('apitoken-label');
     this.tokenExpire = document.getElementById('expiretoken-label');
@@ -55,6 +56,7 @@ OptionsController.prototype = {
     loadFromFileButton: null,
     openFileDialog: null,
     clearButton: null,
+    sitesToFetchLocally: null,
 
     allowSpaceCheck: null,
     archiveByDefault: null,
@@ -80,6 +82,7 @@ OptionsController.prototype = {
         this.openFileDialog.addEventListener('change', this.loadFromFile.bind(this));
         this.httpsButton.addEventListener('click', this.httpsButtonClick.bind(this));
         this.autoAddSingleTag.addEventListener('click', this.autoAddSingleTagClick.bind(this));
+        this.sitesToFetchLocally_.addEventListener('input', this.sitesToFetchInput.bind(this));
     },
 
     httpsButtonClick: function () {
@@ -148,6 +151,11 @@ OptionsController.prototype = {
 
     autoAddSingleTagClick: function (e) {
         Object.assign(this.data, { AutoAddSingleTag: this.autoAddSingleTag.checked });
+        this.port.postMessage({ request: 'setup-save', data: this.data });
+    },
+
+    sitesToFetchInput: function (e) {
+        Object.assign(this.data, { sitesToFetchLocally: this.sitesToFetchLocally_.value });
         this.port.postMessage({ request: 'setup-save', data: this.data });
     },
 
@@ -459,6 +467,7 @@ OptionsController.prototype = {
         this.allowExistCheck.checked = this.data.AllowExistCheck;
         this.autoAddSingleTag.checked = this.data.AutoAddSingleTag;
         this.debugEl.checked = this.data.Debug;
+        this.sitesToFetchLocally_.value = this.data.sitesToFetchLocally;
     },
 
     messageListener: function (msg) {

--- a/wallabagger/js/popup.js
+++ b/wallabagger/js/popup.js
@@ -609,7 +609,21 @@ PopupController.prototype = {
             this.cardTitle.textContent = tab.title;
             this.entryUrl.textContent = /(\w+:\/\/)([^/]+)\/(.*)/.exec(tab.url)[2];
             this.enableTagsInput();
-            this.port.postMessage({ request: 'save', tabUrl: tab.url });
+
+            browser.runtime.onMessage.addListener(event => {
+                if (typeof event.wallabagSaveArticleContent === 'undefined') {
+                    return;
+                }
+
+                this.port.postMessage({ request: 'save', tabUrl: tab.url, title: tab.title, content: event.wallabagSaveArticleContent });
+            });
+
+            browser.tabs.executeScript(
+                tab.id,
+                {
+                    code: 'browser.runtime.sendMessage({"wallabagSaveArticleContent": window.document.body.innerHTML});'
+                }
+            );
         });
     },
 

--- a/wallabagger/js/wallabag-api.js
+++ b/wallabagger/js/wallabag-api.js
@@ -17,7 +17,8 @@ WallabagApi.prototype = {
         AllowSpaceInTags: false,
         AllowExistCheck: false,
         Debug: false,
-        AutoAddSingleTag: false
+        AutoAddSingleTag: false,
+        sitesToFetchLocally: null
     },
 
     data: {},
@@ -176,10 +177,28 @@ WallabagApi.prototype = {
         });
     },
 
-    SavePage: function (pageUrl) {
-        const content = { url: pageUrl };
+    IsSiteToFetchLocally: function (pageUrl) {
+        if (!this.data.sitesToFetchLocally) {
+            return false;
+        }
+
+        const sites = this.data.sitesToFetchLocally.split('\n');
+
+        return sites.filter(function (item) {
+            return pageUrl.indexOf(item) === 0;
+        }).length > 0;
+    },
+
+    SavePage: function (options) {
+        const content = { url: options.url };
         if (this.data.ArchiveByDefault === true) {
             content.archive = 1;
+        }
+        if (options.title) {
+            content.title = options.title;
+        }
+        if (options.content) {
+            content.content = options.content;
         }
         const entriesUrl = `${this.data.Url}/api/entries.json`;
         return this.CheckToken().then(a =>

--- a/wallabagger/options.html
+++ b/wallabagger/options.html
@@ -153,6 +153,13 @@
                     </div>
                 </div>
 
+                <div class="form-group">
+                    <label class="form-label" for="sites_to_fetch_locally-textarea" data-i18n="Sites_locally">Sites to fetch locally</label>
+                    <div class="input-group">
+                        <textarea class="form-input" id="sites_to_fetch_locally-textarea"></textarea>
+                    </div>
+                </div>
+
             </form>
         </div>
         <div class="column side-column">


### PR DESCRIPTION
Some websites like https://www.arretsurimages.net are Single Page Applications behind a Paywall.
Those websites cannot be fetched by wallabag using the credentials API.

This PR adds an option where you can list the websites that you want to fetch locally
![Capture d’écran du 2021-12-05 17-17-57](https://user-images.githubusercontent.com/320372/144754557-c55b000d-ec01-4996-82b2-0a21fca242b8.png)

The tab's page DOM will be used as content and the tab's title will be used as title.