### PR TITLE
Edge hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ More information on websites: [wallabag.org](https://wallabag.org) and [github.c
 
 ## Installation
 
-- From [Chrome WebStore](https://chrome.google.com/webstore/detail/wallabagger/gbmgphmejlcoihgedabhgjdkcahacjlj)
-- By .crx file
-- As unpacked folder (developer mode)
+- Chrome browser users can install extension from [Chrome WebStore](https://chrome.google.com/webstore/detail/wallabagger/gbmgphmejlcoihgedabhgjdkcahacjlj)
+- Edge browser users also use [Chrome WebStore](https://chrome.google.com/webstore/detail/wallabagger/gbmgphmejlcoihgedabhgjdkcahacjlj) (need to 'Allow extensions from other stores')
 - Opera and Yandex browsers users can install the extension from [Opera extension site](https://addons.opera.com/ru/extensions/details/wallabagger/)
 - Firefox browsers users can install the extension from [Mozilla add-ons storage](https://addons.mozilla.org/en-US/firefox/addon/wallabagger/)
-- Edge browser users can install the extension from [Microsoft store](https://www.microsoft.com/en-us/store/p/wallabagger/9p41cnlppmfz)
+- By .crx file
+- As unpacked folder (developer mode)
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ More information on websites: [wallabag.org](https://wallabag.org) and [github.c
 
 ## Installation
 
-- Chrome browser users can install extension from [Chrome WebStore](https://chrome.google.com/webstore/detail/wallabagger/gbmgphmejlcoihgedabhgjdkcahacjlj)
-- Edge browser users also use [Chrome WebStore](https://chrome.google.com/webstore/detail/wallabagger/gbmgphmejlcoihgedabhgjdkcahacjlj) (need to 'Allow extensions from other stores')
-- Opera and Yandex browsers users can install the extension from [Opera extension site](https://addons.opera.com/ru/extensions/details/wallabagger/)
+- Chrome browsers users can install extension from [Chrome WebStore](https://chrome.google.com/webstore/detail/wallabagger/gbmgphmejlcoihgedabhgjdkcahacjlj)
+- Edge browsers users also use [Chrome WebStore](https://chrome.google.com/webstore/detail/wallabagger/gbmgphmejlcoihgedabhgjdkcahacjlj) (need to 'Allow extensions from other stores')
 - Firefox browsers users can install the extension from [Mozilla add-ons storage](https://addons.mozilla.org/en-US/firefox/addon/wallabagger/)
+- Opera and Yandex browsers users can install the extension from [Opera extension site](https://addons.opera.com/ru/extensions/details/wallabagger/)
 - By .crx file
 - As unpacked folder (developer mode)
 


### PR DESCRIPTION
- changed installation path for Edge browser
- moved manual installation options to the end of list
- ATT: Link for Opera/Yandex don't work. I couldn't find the extension on the opera store. I kept the link in readme for now, but maybe you want to remove it.